### PR TITLE
Use common URI

### DIFF
--- a/src/console-view.js
+++ b/src/console-view.js
@@ -25,7 +25,7 @@ export default class ConsoleView extends View {
 	}
 
 	getUri() {
-		return `particle-dev://editor/${this.getPath()}`;
+		return `atom://console-panel/${this.getPath()}`;
 	}
 
 	getDefaultLocation() {


### PR DESCRIPTION
Is there a specific reason why you chose a custom URI for the view? The common way is to use an `atom://` URI.